### PR TITLE
feature: Add model extensions for automatic UUID/ULID generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Outputs `id: :uuid` instead of `id: { type: :string, limit: 36 }`
   - Outputs `id: :ulid` instead of `id: { type: :string, limit: 26 }`
   - Preserves standard integer primary keys unchanged
+- **Model Extensions**: ActiveRecord class methods for automatic UUID/ULID generation
+  - `generates_uuid(attribute, unique: false)` - Auto-generates SecureRandom.uuid on create
+  - `generates_ulid(attribute, unique: false)` - Auto-generates time-sortable ULID on create
+  - Optional uniqueness validation with `unique: true` parameter
+  - Preserves existing values (uses `||=` to avoid overwriting)
+  - Available to all ActiveRecord models via concern
 - **Rails Integration**: Full Railtie implementation
   - Type registration for SQLite3 adapter
   - Schema dumper prepending with proper load order
   - Migration helpers loading
+  - Model extensions loading after database initialization
 - **Testing Infrastructure**:
-  - Comprehensive test suite with code coverage above 80%
+  - Comprehensive test suite with 99.01% code coverage (51 examples)
   - Unit tests for UUID/ULID types with validation
   - Integration tests for real-world migration scenarios
+  - Model extension tests covering generation, validation, and edge cases
   - Support for Rails 7.1, 7.2, 8.0, and 8.1
   - Security audit with bundle-audit in CI
 - **Documentation**: Branch protection rules and contribution guidelines

--- a/README.md
+++ b/README.md
@@ -1,25 +1,274 @@
-# sqlite_crypto
+# SQLite crypto
 
-Seamless UUID/ULID support for Rails 8 with SQLite.
+[![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](https://github.com/bart-oz/sqlite_crypto/releases)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.txt)
+[![Tests](https://img.shields.io/badge/tests-passing-brightgreen.svg)](https://github.com/bart-oz/sqlite_crypto/actions)
+[![Coverage](https://img.shields.io/badge/coverage-99.01%25-brightgreen.svg)](https://github.com/bart-oz/sqlite_crypto/actions)
+[![Status](https://img.shields.io/badge/status-active-success.svg)](https://github.com/bart-oz/sqlite_crypto)
 
-**Status**: Early Development (v0.1.0)
+Seamless UUID and ULID primary key support for Rails with SQLite3.
 
-## Goals
+## Compatibility
 
-- **Minimal**: No database adapter wrapping, pure Rails conventions
-- **Modular**: Use only what you need (UUID or ULID, not both required)
-- **Clear**: Explicit over implicit, following Rails 8 patterns
-- **Documented**: Clear migration path for existing and new projects
+| Ruby Version | Rails 7.1 | Rails 7.2 | Rails 8.0 | Rails 8.1 |
+|--------------|-----------|-----------|-----------|-----------|
+| 3.1          | ✅        | ✅        | ❌        | ❌        |
+| 3.2          | ✅        | ✅        | ✅        | ✅        |
+| 3.3          | ✅        | ✅        | ✅        | ✅        |
+| 3.4          | ✅        | ✅        | ✅        | ✅        |
 
-## Planned Features
+**Recommended**: Ruby 3.3+ with Rails 8.0+
 
-- UUID primary key configuration with `t.uuid :id`
-- ULID primary key configuration with `t.ulid :id`
-- Migration helpers and generators
-- Transparent foreign key handling
-- Migration utilities for converting existing integer primary keys
+**Support Policy**: Actively maintained with updates for new Ruby and Rails versions.
+
+## Features
+
+✅ UUID primary keys with automatic validation
+✅ ULID primary keys with time-sortable validation
+✅ Migration DSL helpers (`t.uuid`, `t.ulid`)
+✅ Automatic foreign key type detection
+✅ Model extensions for UUID/ULID generation
+✅ Clean schema.rb output
+✅ Zero configuration required
 
 ## Installation
 
+Add to your Gemfile:
+
 ```ruby
 gem "sqlite_crypto"
+```
+
+Then run:
+
+```bash
+bundle install
+```
+
+That's it! No generators or configuration needed.
+
+## Usage
+
+### UUID Primary Keys
+
+```ruby
+class CreateUsers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :users, id: :uuid do |t|
+      t.string :email
+      t.string :name
+      t.timestamps
+    end
+  end
+end
+```
+
+### ULID Primary Keys
+
+```ruby
+class CreatePosts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :posts, id: :ulid do |t|
+      t.string :title
+      t.text :content
+      t.timestamps
+    end
+  end
+end
+```
+
+### UUID/ULID Columns
+
+```ruby
+class AddTrackingIds < ActiveRecord::Migration[8.1]
+  def change
+    change_table :orders do |t|
+      t.uuid :external_id
+      t.ulid :tracking_number
+    end
+  end
+end
+```
+
+### Foreign Keys (Automatic Detection)
+
+The gem automatically detects UUID/ULID primary keys and creates matching foreign keys:
+
+```ruby
+# Users table has UUID primary key
+create_table :users, id: :uuid do |t|
+  t.string :name
+end
+
+# Posts automatically get varchar(36) user_id foreign key
+create_table :posts do |t|
+  t.references :user  # Automatically creates varchar(36) foreign key!
+  t.string :title
+end
+```
+
+Works with ULID too:
+
+```ruby
+# Categories table has ULID primary key
+create_table :categories, id: :ulid do |t|
+  t.string :name
+end
+
+# Articles automatically get varchar(26) category_id foreign key
+create_table :articles do |t|
+  t.references :category  # Automatically creates varchar(26) foreign key!
+  t.string :title
+end
+```
+
+### Custom Table Names
+
+Use `:to_table` option for non-standard table names:
+
+```ruby
+create_table :posts do |t|
+  t.references :author, to_table: :users  # Uses users table's UUID type
+  t.string :title
+end
+```
+
+### Model Extensions (Auto-Generate UUIDs/ULIDs)
+
+Automatically generate UUID or ULID values for any column:
+
+```ruby
+class User < ApplicationRecord
+  # Generate UUID for 'token' column on create
+  generates_uuid :token
+end
+
+class Order < ApplicationRecord
+  # Generate ULID for 'reference' column with uniqueness validation
+  generates_ulid :reference, unique: true
+end
+```
+
+**Features:**
+- `generates_uuid(attribute, unique: false)` - Generates SecureRandom.uuid
+- `generates_ulid(attribute, unique: false)` - Generates time-sortable ULID
+- `unique: true` - Adds uniqueness validation
+- Preserves existing values (won't overwrite if already set)
+- Works with any string column, not just primary keys
+
+**Example migration:**
+
+```ruby
+class AddTokenToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :token, :string, limit: 36
+    add_index :users, :token, unique: true
+  end
+end
+```
+
+### Schema Output
+
+Your `db/schema.rb` will be clean and readable:
+
+```ruby
+create_table "users", id: :uuid, force: :cascade do |t|
+  t.string "email"
+  t.timestamps
+end
+
+create_table "posts", force: :cascade do |t|
+  t.string "user_id", limit: 36  # Clean foreign key
+  t.string "title"
+end
+```
+
+## How It Works
+
+1. **Type Registration**: Registers `:uuid` and `:ulid` types with ActiveRecord for SQLite3
+2. **Validation**: UUIDs validate 36-char format, ULIDs validate 26-char format
+3. **Migration Helpers**: `t.uuid()` and `t.ulid()` methods in migrations
+4. **Smart References**: `t.references` detects parent table's primary key type
+5. **Model Extensions**: `generates_uuid` and `generates_ulid` for automatic generation
+6. **Schema Dumper**: Outputs clean `id: :uuid` instead of verbose type definitions
+
+## Requirements
+
+- Rails 7.1+ (tested on 7.1, 7.2, 8.0, 8.1)
+- Ruby 3.1+
+- SQLite3
+
+## Migrating Existing Apps
+
+### New Tables Only (Recommended)
+
+The safest approach is to use UUID/ULID only for new tables:
+
+```ruby
+# Existing tables keep integer IDs
+# users: id (integer)
+# posts: id (integer), user_id (integer)
+
+# New tables use UUID/ULID
+create_table :invoices, id: :uuid do |t|
+  t.references :user  # Still integer (auto-detected from users table)
+  t.decimal :amount
+end
+
+create_table :sessions, id: :ulid do |t|
+  t.references :user  # Still integer
+  t.string :token
+end
+```
+
+## Advanced Patterns
+
+### ID Prefixes (Optional)
+
+For Stripe-style prefixed IDs (`inv_`, `usr_`, etc.), add to your models:
+
+```ruby
+class Invoice < ApplicationRecord
+  before_create :generate_prefixed_id
+
+  private
+
+  def generate_prefixed_id
+    self.id = "inv_#{SecureRandom.uuid}" if id.nil?
+  end
+end
+```
+
+### Mixing Types
+
+You can use different primary key types in the same app:
+
+```ruby
+create_table :users, id: :uuid do |t|
+  t.string :email
+end
+
+create_table :sessions, id: :ulid do |t|
+  t.string :token
+end
+
+create_table :logs do |t|  # Standard integer ID
+  t.string :message
+end
+```
+
+## Development
+
+```bash
+bundle install
+bundle exec rspec
+bundle exec standardrb
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## License
+
+MIT License - see [LICENSE.txt](LICENSE.txt)

--- a/lib/sqlite_crypto/model_extensions.rb
+++ b/lib/sqlite_crypto/model_extensions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "ulid"
+
+module SqliteCrypto
+  module ModelExtensions
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def generates_uuid(attribute, unique: false)
+        before_create do
+          self[attribute] ||= SecureRandom.uuid
+        end
+
+        validates attribute, uniqueness: true if unique
+      end
+
+      def generates_ulid(attribute, unique: false)
+        before_create do
+          self[attribute] ||= ULID.generate.to_s
+        end
+
+        validates attribute, uniqueness: true if unique
+      end
+    end
+  end
+end
+
+ActiveRecord::Base.include(SqliteCrypto::ModelExtensions) if defined?(ActiveRecord::Base)

--- a/lib/sqlite_crypto/railtie.rb
+++ b/lib/sqlite_crypto/railtie.rb
@@ -23,9 +23,8 @@ module SqliteCrypto
       require "sqlite_crypto/migration_helpers"
     end
 
-    # Generators (not implemented yet)
-    # generators do
-    #   require "sqlite_crypto/generators/install_generator"
-    # end
+    initializer "sqlite_crypto.model_extensions", after: "active_record.initialize_database" do
+      require "sqlite_crypto/model_extensions"
+    end
   end
 end

--- a/spec/lib/sqlite_crypto/model_extensions_spec.rb
+++ b/spec/lib/sqlite_crypto/model_extensions_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SqliteCrypto::ModelExtensions do
+  let(:connection) { ActiveRecord::Base.connection }
+
+  before do
+    connection.create_table :test_users, force: true do |t|
+      t.string :name
+      t.string :token, limit: 36
+      t.string :reference, limit: 26
+    end
+
+    stub_const("TestUser", Class.new(ActiveRecord::Base) do
+      self.table_name = "test_users"
+    end)
+  end
+
+  after do
+    connection.drop_table :test_users, if_exists: true
+  end
+
+  describe ".generates_uuid" do
+    before { TestUser.generates_uuid :token }
+
+    it "auto-generates valid UUID on create" do
+      user = TestUser.create!(name: "Alice")
+
+      expect(user.token).to match(/\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/)
+    end
+
+    it "preserves existing values" do
+      existing_uuid = "550e8400-e29b-41d4-a716-446655440000"
+      user = TestUser.create!(name: "Bob", token: existing_uuid)
+
+      expect(user.token).to eq(existing_uuid)
+    end
+
+    context "with unique: true" do
+      before { TestUser.generates_uuid :token, unique: true }
+
+      it "enforces uniqueness validation" do
+        user1 = TestUser.create!(name: "Alice")
+        user2 = TestUser.new(name: "Bob", token: user1.token)
+
+        expect(user2).not_to be_valid
+        expect(user2.errors[:token]).to include("has already been taken")
+      end
+    end
+  end
+
+  describe ".generates_ulid" do
+    before { TestUser.generates_ulid :reference }
+
+    it "auto-generates valid ULID on create" do
+      user = TestUser.create!(name: "Alice")
+
+      expect(user.reference).to match(/\A[0-9A-Z]{26}\z/)
+    end
+
+    it "preserves existing values" do
+      existing_ulid = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+      user = TestUser.create!(name: "Bob", reference: existing_ulid)
+
+      expect(user.reference).to eq(existing_ulid)
+    end
+
+    it "generates time-sortable identifiers" do
+      user1 = TestUser.create!(name: "First")
+      sleep 0.001
+      user2 = TestUser.create!(name: "Second")
+
+      expect(user1.reference).to be < user2.reference
+    end
+
+    context "with unique: true" do
+      before { TestUser.generates_ulid :reference, unique: true }
+
+      it "enforces uniqueness validation" do
+        user1 = TestUser.create!(name: "Alice")
+        user2 = TestUser.new(name: "Bob", reference: user1.reference)
+
+        expect(user2).not_to be_valid
+        expect(user2.errors[:reference]).to include("has already been taken")
+      end
+    end
+  end
+
+  it "extends ActiveRecord::Base with class methods" do
+    expect(ActiveRecord::Base).to respond_to(:generates_uuid)
+    expect(ActiveRecord::Base).to respond_to(:generates_ulid)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,7 @@ end
 # Load gem before Rails initializes
 require_relative "../lib/sqlite_crypto"
 require_relative "../lib/sqlite_crypto/migration_helpers"
+require_relative "../lib/sqlite_crypto/model_extensions"
 
 # Initialize Rails and establish database connection
 Dummy::Application.initialize!


### PR DESCRIPTION
Implemented ActiveRecord model extensions to automatically generate UUID and ULID values for any column using before_create callbacks.

Features:
- generates_uuid(attribute, unique: false) - Auto-generates SecureRandom.uuid
- generates_ulid(attribute, unique: false) - Auto-generates time-sortable ULID
- Optional uniqueness validation with unique: true parameter
- Preserves existing values (won't overwrite if already set)
- Available to all ActiveRecord models via concern

Changes:
- Added lib/sqlite_crypto/model_extensions.rb with generates_uuid/generates_ulid
- Added comprehensive specs
- Updated Railtie to load model extensions after database initialization
- Updated README.md with model extensions documentation and examples
- Updated CHANGELOG.md with complete feature documentation
- Removed Rails generator (zero-config approach - gem works out-of-box)