### PR TITLE
Feat: Security fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-01-14
+
+### Security
+- **CRITICAL:**
+  - Fixed regex anchor vulnerability in UUID/ULID validators
+  - Fixed action_text-trix XSS vulnerability by updating the version to '>= 2.1.16'
+
+### Changed
+- **Eager configuration validation**: Setting `uuid_version = :v7` on Ruby < 3.3 now fails at boot time with clear error message instead of runtime failure
+- **Namespace cleanup**: `uuid` and `ulid` schema helpers now scoped to `ActiveRecord::Schema` instead of global `Object`
+- **Performance**: Cached Ruby version check in `V7_AVAILABLE` constant (eliminates repeated `Gem::Version` comparisons)
+- **Boot time**: Added lazy loading with `ActiveSupport.on_load(:active_record)` hook for faster Rails initialization
+- **Migration performance**: Memoized primary key type detection to avoid redundant database queries
+
+### Removed
+- Unused `SqliteCrypto::Error` class
+- Unused `SqliteCrypto.load_extensions` placeholder method
+
+### Internal
+- Simplified configuration defaults to reuse `Generators::Uuid.v7_available?` logic
+- Improved code organization and removed dead code
+
 ## [2.0.0] - 2026-01-08
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ source "https://rubygems.org"
 
 gemspec
 
+# Security: Fix Trix XSS vulnerability (GHSA-g9jg-w8vm-g96v)
+gem "action_text-trix", ">= 2.1.16"
+
 group :development do
   gem "rake", "~> 13.3.1"
   gem "standard", "~> 1.52.0"

--- a/README.md
+++ b/README.md
@@ -4,88 +4,80 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.txt)
 [![types supported](https://img.shields.io/badge/types-ULID,_UUIDv7/v4-brightgreen.svg)](https://github.com/bart-oz/sqlite_crypto)
 [![Tests](https://img.shields.io/badge/tests-passing-brightgreen.svg)](https://github.com/bart-oz/sqlite_crypto/actions)
-[![Coverage](https://img.shields.io/badge/coverage-98.59%25-brightgreen.svg)](https://github.com/bart-oz/sqlite_crypto/actions)
+[![Coverage](https://img.shields.io/badge/coverage-98.06%25-brightgreen.svg)](https://github.com/bart-oz/sqlite_crypto/actions)
 [![Status](https://img.shields.io/badge/status-active-success.svg)](https://github.com/bart-oz/sqlite_crypto)
 
-**Drop-in UUID and ULID primary keys for Rails + SQLite3**
+## Overview
+
+Seamless UUID and ULID primary key support for Rails applications using SQLite3. Handles type registration, validation, foreign key detection, and schema generation automatically.
 
 ```ruby
-# Just use :uuid or :ulid instead of default integer IDs
 create_table :users, id: :uuid do |t|
   t.string :email
+  t.timestamps
 end
 ```
 
-## What You Get
+**Key capabilities:**
+- UUID primary keys (v4 random or v7 time-ordered)
+- ULID primary keys (time-sortable, compact)
+- Automatic foreign key type detection
+- Model-level ID generation
+- Clean schema.rb output
+- Zero external dependencies
 
-✅ **UUID primary keys** (v4 random or v7 time-sortable)<br/>
-✅ **ULID primary keys** (time-sortable, 26 characters)<br/>
-✅ **Automatic foreign key detection** - `t.references` just works<br/>
-✅ **Model generators** - `generates_uuid :token`<br/>
-✅ **Clean schema.rb** - No verbose type definitions<br/>
-✅ **Zero dependencies** - Uses Ruby's built-in SecureRandom<br/>
+## Compatibility
 
-## Quick Start
+**Ruby & Rails:**
+
+|       | Rails 7.1 | Rails 7.2 | Rails 8.0 | Rails 8.1 |
+|-------|-----------|-----------|-----------|-----------|
+| Ruby 3.1 | ✓ | ✓ | - | - |
+| Ruby 3.2 | ✓ | ✓ | ✓ | ✓ |
+| Ruby 3.3 | ✓ | ✓ | ✓ | ✓ |
+| Ruby 3.4 | ✓ | ✓ | ✓ | ✓ |
+| Ruby 4.0 | ✓ | ✓ | ✓ | ✓ |
+
+**UUID Versions:**
+
+| Version | Ruby 3.1/3.2 | Ruby 3.3+ |
+|---------|--------------|-----------|
+| v4 (random) | ✓ | ✓ |
+| v7 (time-ordered) | - | ✓ |
+
+**Database:** SQLite3
+
+## Installation
+
+```ruby
+# Gemfile
+gem "sqlite_crypto"
+```
 
 ```bash
-bundle add sqlite_crypto
+bundle install
 rails generate sqlite_crypto:install
 ```
 
-## ID Type Comparison
-
-| Type | Format | Performance | Use Case |
-|------|--------|-------------|----------|
-| **Integer** | `1, 2, 3...` | Baseline | Simple apps, no distribution |
-| **UUIDv7** | `018d3f91-...` (36 chars) | ~1-3% slower inserts | ⭐ **Recommended** - Time-sortable + fast |
-| **UUIDv4** | `550e8400-e29b-...` (36 chars) | ~2-5% slower inserts | Random IDs, legacy compatibility |
-| **ULID** | `01ARZ3NDEK...` (26 chars) | ~3-7% slower inserts | Time-sortable, compact format |
-
-### Why UUIDv7 is Recommended
-
-UUIDv7 embeds a timestamp in the first 48 bits, making IDs naturally sortable by creation time:
-
-```
-UUIDv7: 018d3f91-8f4a-7000-9e7b-4a5c8d2e1f3a  ← Time-based (inserts cluster at end)
-UUIDv4: 6ba7b810-9dad-11d1-80b4-00c04fd430c8  ← Random (causes index fragmentation)
-```
-
-**Performance Impact:**
-- New records insert at the **end of B-tree index** (not random positions)
-- Reduces page splits and fragmentation
-- ~40% faster index writes vs UUIDv4 at scale (10k+ records)
-
-**Requirements:** Ruby 3.3+ (falls back to v4 on older versions)
+The generator creates `config/initializers/sqlite_crypto.rb` for configuration.
 
 ## Configuration
 
-### Choose UUID Version (v4 or v7)
-
-After running `rails generate sqlite_crypto:install`:
+**1. Configure UUID Version**
 
 ```ruby
 # config/initializers/sqlite_crypto.rb
 SqliteCrypto.configure do |config|
-  config.uuid_version = :v7  # Recommended (requires Ruby 3.3+)
-  # config.uuid_version = :v4  # Use this for Ruby 3.1/3.2
+  config.uuid_version = :v7  # or :v4
 end
 ```
 
-**Ruby Version Support:**
-- Ruby 3.3+ → v4 and v7
-- Ruby 3.1/3.2 → v4 only
+The gem automatically selects a default based on your Ruby version (v7 for Ruby 3.3+, v4 otherwise).
 
-Check programmatically:
-```ruby
-SqliteCrypto::Generators::Uuid.v7_available?  # => true/false
-```
-
-## Usage Examples
-
-### UUID Primary Keys
+**2. Create Tables with UUID/ULID**
 
 ```ruby
-class CreateUsers < ActiveRecord::Migration[8.1]
+class CreateUsers < ActiveRecord::Migration[8.0]
   def change
     create_table :users, id: :uuid do |t|
       t.string :email
@@ -95,106 +87,96 @@ class CreateUsers < ActiveRecord::Migration[8.1]
 end
 ```
 
-Result:
+**3. Use Your Models**
+
 ```ruby
-user = User.create!(email: "alice@example.com")
-user.id  # => "018d3f91-8f4a-7000-9e7b-4a5c8d2e1f3a" (UUIDv7)
+user = User.create!(email: "test@example.com")
+user.id  # => "018d3f91-8f4a-7000-9e7b-4a5c8d2e1f3a"
 ```
 
-### ULID Primary Keys
+## Usage
+
+**Primary Keys**
+
+Create tables with UUID or ULID primary keys:
 
 ```ruby
-class CreatePosts < ActiveRecord::Migration[8.1]
-  def change
-    create_table :posts, id: :ulid do |t|
-      t.string :title
-      t.timestamps
-    end
-  end
-end
-```
-
-Result:
-```ruby
-post = Post.create!(title: "Hello World")
-post.id  # => "01ARZ3NDEKTSV4RRFFQ69G5FAV" (26 chars, time-sortable)
-```
-
-### Automatic Foreign Keys
-
-The gem **automatically detects** parent table ID types:
-
-```ruby
-# Users have UUID primary keys
+# UUID
 create_table :users, id: :uuid do |t|
-  t.string :name
+  t.string :email
 end
 
-# Posts automatically get varchar(36) foreign keys
-create_table :posts do |t|
-  t.references :user      # Auto-detected as varchar(36)!
+# ULID
+create_table :posts, id: :ulid do |t|
   t.string :title
 end
 ```
 
-Works with ULID too:
+**Foreign Keys**
+
+Foreign key types are automatically detected from parent tables:
+
 ```ruby
-create_table :categories, id: :ulid do |t|
+create_table :users, id: :uuid do |t|
   t.string :name
 end
 
-create_table :articles do |t|
-  t.references :category  # Auto-detected as varchar(26)!
+create_table :posts do |t|
+  t.references :user  # Automatically varchar(36)
+  t.string :title
 end
 ```
 
-### Generate UUIDs/ULIDs for Any Column
+**Model-Level Generation**
+
+Generate UUIDs or ULIDs for any column:
 
 ```ruby
 class User < ApplicationRecord
-  generates_uuid :token                    # Auto-generate on create
-  generates_ulid :reference, unique: true  # With uniqueness validation
+  generates_uuid :api_token
+  generates_ulid :tracking_id, unique: true
 end
 
-user = User.create!(email: "test@example.com")
-user.token      # => "018d3f91-..." (auto-generated)
-user.reference  # => "01ARZ3NDEK..." (auto-generated + validated)
+user = User.create!
+user.api_token    # => "550e8400-e29b-41d4-a716-446655440000"
+user.tracking_id  # => "01ARZ3NDEKTSV4RRFFQ69G5FAV"
 ```
 
-## Requirements
+## ID Types
 
-- **Ruby**: 3.1+ (3.3+ for UUIDv7)
-- **Rails**: 7.1, 7.2, 8.0, 8.1
-- **Database**: SQLite3
+**Characteristics**
 
-## Performance Benchmarks
+| Type | Length | Format | Ordering | Ruby Version |
+|------|--------|--------|----------|--------------|
+| Integer | 8 bytes | Sequential numbers | Sequential | Any |
+| UUIDv4 | 36 chars | `xxxxxxxx-xxxx-4xxx-...` | Random | 3.1+ |
+| UUIDv7 | 36 chars | `xxxxxxxx-xxxx-7xxx-...` | Time-based | 3.3+ |
+| ULID | 26 chars | `01ARZ3NDEK...` | Time-based | 3.1+ |
 
-Run your own benchmarks: `bundle exec rspec --tag performance`
+**Performance**
 
-**Typical results (M1 Mac, SQLite3, 10k records):**
+Benchmarks with 10,000 records on SQLite3:
 
-| Operation | Integer (baseline) | UUIDv4 | UUIDv7 | ULID |
-|-----------|-------------------|--------|--------|------|
-| Insert (10k) | 1.00x | 1.02x | 1.01x | 1.05x |
-| Query by ID | 1.00x | 1.03x | 1.03x | 1.04x |
-| Index size | 100% | 145% | 145% | 130% |
+| Type | Insert | Query | Index Size |
+|------|--------|-------|------------|
+| Integer | 1.00x | 1.00x | 100% |
+| UUIDv4 | 1.02x | 1.03x | 145% |
+| UUIDv7 | 1.01x | 1.03x | 145% |
+| ULID | 1.05x | 1.04x | 130% |
 
-**Key takeaway:** UUIDv7 has nearly identical performance to v4, with better write scaling.
+Run your own: `bundle exec rspec --tag performance`
+
 ## Advanced Usage
 
-### Custom Table Names
-
-Use `:to_table` for non-standard associations:
+**Non-Standard Table Names**
 
 ```ruby
 create_table :posts do |t|
-  t.references :author, to_table: :users  # Uses users table's ID type
+  t.references :author, to_table: :users
 end
 ```
 
-### Mixing ID Types
-
-Different tables can use different ID types:
+**Mixed ID Types**
 
 ```ruby
 create_table :users, id: :uuid do |t|
@@ -202,65 +184,38 @@ create_table :users, id: :uuid do |t|
 end
 
 create_table :sessions, id: :ulid do |t|
-  t.references :user  # Auto-detected as varchar(36)
+  t.references :user
 end
 
-create_table :logs do |t|  # Integer ID (default)
-  t.string :message
-end
-```
-
-### ID Prefixes (Stripe-style)
-
-```ruby
-class Invoice < ApplicationRecord
-  before_create :add_prefix
-
-  private
-  def add_prefix
-    self.id = "inv_#{SecureRandom.uuid}" if id.nil?
-  end
+create_table :logs do |t|  # Integer ID
+  t.text :message
 end
 ```
 
 ## Migrating Existing Apps
 
-Use UUID/ULID only for **new tables**:
+Add UUID/ULID to new tables while keeping integer IDs on existing tables:
 
 ```ruby
-# Keep existing integer IDs
-# users: id (integer)
-# posts: id (integer), user_id (integer)
-
-# New tables use UUID/ULID
+# Existing tables unchanged
 create_table :invoices, id: :uuid do |t|
-  t.references :user  # Still integer (auto-detected)
+  t.references :user  # Detects integer from users table
   t.decimal :amount
 end
 ```
-
-## How It Works
-
-1. **Type Registration** - Registers `:uuid` and `:ulid` with ActiveRecord's SQLite3 adapter
-2. **Validation** - UUIDs: 36-char format, ULIDs: 26-char format
-3. **Migration Helpers** - `t.uuid()` and `t.ulid()` in migrations
-4. **Smart References** - `t.references` detects parent table ID type
-5. **Model Extensions** - `generates_uuid`/`generates_ulid` for auto-generation
-6. **Schema Dumper** - Clean output: `id: :uuid` instead of verbose definitions
 
 ## Development
 
 ```bash
 bundle install
-bundle exec rspec                    # Run tests
-bundle exec standardrb               # Lint
-bundle exec rspec --tag performance  # Benchmarks
+bundle exec rspec
+bundle exec standardrb
 ```
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+Bug reports and pull requests are welcome on GitHub at https://github.com/bart-oz/sqlite_crypto.
 
 ## License
 
-MIT License - see [LICENSE.txt](LICENSE.txt)
+The gem is available as open source under the terms of the [MIT License](LICENSE.txt).

--- a/lib/sqlite_crypto.rb
+++ b/lib/sqlite_crypto.rb
@@ -8,8 +8,6 @@ require "sqlite_crypto/schema_definitions"
 require "sqlite_crypto/generators/uuid"
 
 module SqliteCrypto
-  class Error < StandardError; end
-
   class << self
     def configuration
       @configuration ||= Configuration.new
@@ -23,9 +21,5 @@ module SqliteCrypto
     def reset_configuration!
       @configuration = Configuration.new
     end
-  end
-
-  def self.load_extensions
-    # Placeholder for future extension loading logic
   end
 end

--- a/lib/sqlite_crypto/configuration.rb
+++ b/lib/sqlite_crypto/configuration.rb
@@ -2,11 +2,31 @@
 
 module SqliteCrypto
   class Configuration
-    attr_accessor :uuid_version
+    attr_reader :uuid_version
 
     def initialize
       # Default to v7 on Ruby 3.3+, v4 on older versions
-      @uuid_version = (Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.3.0")) ? :v7 : :v4
+      @uuid_version = Generators::Uuid.v7_available? ? :v7 : :v4
+    end
+
+    def uuid_version=(version)
+      validate_uuid_version!(version)
+      @uuid_version = version
+    end
+
+    private
+
+    def validate_uuid_version!(version)
+      valid_versions = [:v4, :v7]
+      unless valid_versions.include?(version)
+        raise ArgumentError, "Invalid UUID version: #{version}. Must be one of #{valid_versions.join(", ")}"
+      end
+
+      if version == :v7 && !Generators::Uuid.v7_available?
+        raise ArgumentError,
+          "UUIDv7 requires Ruby 3.3+. Current: #{RUBY_VERSION}. " \
+          "Use config.uuid_version = :v4 or upgrade Ruby."
+      end
     end
   end
 end

--- a/lib/sqlite_crypto/generators/uuid.rb
+++ b/lib/sqlite_crypto/generators/uuid.rb
@@ -6,7 +6,7 @@ module SqliteCrypto
   module Generators
     class Uuid
       MINIMUM_RUBY_FOR_V7 = Gem::Version.new("3.3.0")
-      CURRENT_RUBY = Gem::Version.new(RUBY_VERSION)
+      V7_AVAILABLE = (Gem::Version.new(RUBY_VERSION) >= MINIMUM_RUBY_FOR_V7)
 
       class << self
         def generate(version: SqliteCrypto.config.uuid_version)
@@ -21,7 +21,7 @@ module SqliteCrypto
         end
 
         def v7_available?
-          CURRENT_RUBY >= MINIMUM_RUBY_FOR_V7
+          V7_AVAILABLE
         end
 
         private

--- a/lib/sqlite_crypto/migration_helpers.rb
+++ b/lib/sqlite_crypto/migration_helpers.rb
@@ -32,6 +32,11 @@ module SqliteCrypto
       private
 
       def detect_primary_key_type(table_name)
+        @pk_type_cache ||= {}
+        @pk_type_cache[table_name] ||= fetch_primary_key_type(table_name)
+      end
+
+      def fetch_primary_key_type(table_name)
         conn = @conn || @base || (respond_to?(:connection) ? connection : nil)
         return nil unless conn&.table_exists?(table_name)
 

--- a/lib/sqlite_crypto/railtie.rb
+++ b/lib/sqlite_crypto/railtie.rb
@@ -10,13 +10,17 @@ module SqliteCrypto
     config.sqlite_crypto = ActiveSupport::OrderedOptions.new
 
     initializer "sqlite_crypto.register_types" do
-      ActiveRecord::Type.register(:uuid, SqliteCrypto::Type::Uuid, adapter: :sqlite3)
-      ActiveRecord::Type.register(:ulid, SqliteCrypto::Type::ULID, adapter: :sqlite3)
+      ActiveSupport.on_load(:active_record) do
+        ActiveRecord::Type.register(:uuid, SqliteCrypto::Type::Uuid, adapter: :sqlite3)
+        ActiveRecord::Type.register(:ulid, SqliteCrypto::Type::ULID, adapter: :sqlite3)
+      end
     end
 
     initializer "sqlite_crypto.native_types" do
-      require "active_record/connection_adapters/sqlite3_adapter"
-      ActiveRecord::ConnectionAdapters::SQLite3Adapter.prepend(SqliteCrypto::Sqlite3AdapterExtension)
+      ActiveSupport.on_load(:active_record) do
+        require "active_record/connection_adapters/sqlite3_adapter"
+        ActiveRecord::ConnectionAdapters::SQLite3Adapter.prepend(SqliteCrypto::Sqlite3AdapterExtension)
+      end
     end
 
     initializer "sqlite_crypto.schema_dumper", after: "active_record.initialize_database" do

--- a/lib/sqlite_crypto/schema_definitions.rb
+++ b/lib/sqlite_crypto/schema_definitions.rb
@@ -13,5 +13,7 @@ module SqliteCrypto
   end
 end
 
-# Extend the main object context for schema.rb loading
-Object.include(SqliteCrypto::SchemaDefinitions)
+# Extend ActiveRecord::Schema context for schema.rb loading (not global Object)
+if defined?(ActiveRecord::Schema)
+  ActiveRecord::Schema.include(SqliteCrypto::SchemaDefinitions)
+end

--- a/lib/sqlite_crypto/type/ulid.rb
+++ b/lib/sqlite_crypto/type/ulid.rb
@@ -5,6 +5,8 @@ require "sqlite_crypto/type/base"
 module SqliteCrypto
   module Type
     class ULID < Base
+      ULID_PATTERN = /\A[0-7][0-9A-Z]{25}\z/i
+
       def type
         :ulid
       end
@@ -12,7 +14,7 @@ module SqliteCrypto
       private
 
       def valid?(value)
-        value.match?(/^[0-7][0-9A-Z]{25}$/i)
+        ULID_PATTERN.match?(value)
       end
     end
   end

--- a/lib/sqlite_crypto/type/uuid.rb
+++ b/lib/sqlite_crypto/type/uuid.rb
@@ -5,6 +5,8 @@ require "sqlite_crypto/type/base"
 module SqliteCrypto
   module Type
     class Uuid < Base
+      UUID_PATTERN = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+
       def type
         :uuid
       end
@@ -12,7 +14,7 @@ module SqliteCrypto
       private
 
       def valid?(value)
-        value.match?(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+        UUID_PATTERN.match?(value)
       end
     end
   end

--- a/lib/sqlite_crypto/version.rb
+++ b/lib/sqlite_crypto/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SqliteCrypto
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
   RUBY_MINIMUM_VERSION = "3.1.0"
   RAILS_MINIMUM_VERSION = "7.1.0"
 end

--- a/spec/lib/schema_definitions_spec.rb
+++ b/spec/lib/schema_definitions_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SqliteCrypto::SchemaDefinitions do
+  describe "namespace scoping" do
+    it "does not pollute Object namespace" do
+      obj = Object.new
+      expect(obj).not_to respond_to(:uuid)
+      expect(obj).not_to respond_to(:ulid)
+    end
+
+    it "module defines uuid method" do
+      expect(described_class.instance_methods).to include(:uuid)
+    end
+
+    it "module defines ulid method" do
+      expect(described_class.instance_methods).to include(:ulid)
+    end
+
+    it "uuid method returns :uuid symbol" do
+      test_class = Class.new do
+        include SqliteCrypto::SchemaDefinitions
+      end
+
+      expect(test_class.new.uuid).to eq(:uuid)
+    end
+
+    it "ulid method returns :ulid symbol" do
+      test_class = Class.new do
+        include SqliteCrypto::SchemaDefinitions
+      end
+
+      expect(test_class.new.ulid).to eq(:ulid)
+    end
+  end
+end

--- a/spec/lib/sqlite_crypto/configuration_spec.rb
+++ b/spec/lib/sqlite_crypto/configuration_spec.rb
@@ -16,9 +16,33 @@ RSpec.describe SqliteCrypto::Configuration do
       expect(config.uuid_version).to eq(:v4)
     end
 
-    it "can be set to :v7 explicitly" do
-      config.uuid_version = :v7
-      expect(config.uuid_version).to eq(:v7)
+    context "when setting :v7" do
+      it "accepts :v7 on Ruby 3.3+" do
+        skip "Only testable on Ruby 3.3+" unless SqliteCrypto::Generators::Uuid.v7_available?
+
+        config.uuid_version = :v7
+        expect(config.uuid_version).to eq(:v7)
+      end
+
+      it "raises ArgumentError on Ruby < 3.3" do
+        skip "Only testable on Ruby < 3.3" if SqliteCrypto::Generators::Uuid.v7_available?
+
+        expect {
+          config.uuid_version = :v7
+        }.to raise_error(ArgumentError, /UUIDv7 requires Ruby 3.3/)
+      end
+    end
+
+    it "raises ArgumentError for invalid versions" do
+      expect {
+        config.uuid_version = :v5
+      }.to raise_error(ArgumentError, /Invalid UUID version: v5/)
+    end
+
+    it "raises ArgumentError for non-symbol versions" do
+      expect {
+        config.uuid_version = "v4"
+      }.to raise_error(ArgumentError, /Invalid UUID version: v4/)
     end
   end
 end

--- a/spec/lib/sqlite_crypto/generators/uuid_spec.rb
+++ b/spec/lib/sqlite_crypto/generators/uuid_spec.rb
@@ -65,13 +65,17 @@ RSpec.describe SqliteCrypto::Generators::Uuid do
       expect(described_class.v7_available?).to eq(true).or eq(false)
     end
 
-    it "returns true for Ruby 3.3+" do
-      stub_const("SqliteCrypto::Generators::Uuid::CURRENT_RUBY", Gem::Version.new("3.3.0"))
+    it "returns cached value from V7_AVAILABLE constant" do
+      expect(described_class.v7_available?).to eq(SqliteCrypto::Generators::Uuid::V7_AVAILABLE)
+    end
+
+    it "returns true on Ruby 3.3+" do
+      skip "Only testable on Ruby 3.3+" unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.3.0")
       expect(described_class.v7_available?).to be true
     end
 
-    it "returns false for Ruby < 3.3" do
-      stub_const("SqliteCrypto::Generators::Uuid::CURRENT_RUBY", Gem::Version.new("3.2.0"))
+    it "returns false on Ruby < 3.3" do
+      skip "Only testable on Ruby < 3.3" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.3.0")
       expect(described_class.v7_available?).to be false
     end
   end

--- a/spec/lib/sqlite_crypto/type/ulid_spec.rb
+++ b/spec/lib/sqlite_crypto/type/ulid_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe SqliteCrypto::Type::ULID do
         expect { type.cast(invalid) }.to raise_error(ArgumentError, /Invalid ULID/)
       end
     end
+
+    it "rejects multiline strings with embedded newlines (security)" do
+      malicious = "01ARZ3NDEKTSV4RRFFQ69G5FAV\n<script>alert('xss')</script>"
+      expect { type.cast(malicious) }.to raise_error(ArgumentError, /Invalid ULID/)
+    end
+
+    it "rejects ULIDs with leading content" do
+      malicious = "prefix-01ARZ3NDEKTSV4RRFFQ69G5FAV"
+      expect { type.cast(malicious) }.to raise_error(ArgumentError, /Invalid ULID/)
+    end
+
+    it "rejects ULIDs with trailing content" do
+      malicious = "01ARZ3NDEKTSV4RRFFQ69G5FAV-suffix"
+      expect { type.cast(malicious) }.to raise_error(ArgumentError, /Invalid ULID/)
+    end
   end
 
   describe "#serialize and #deserialize" do

--- a/spec/lib/sqlite_crypto/type/uuid_spec.rb
+++ b/spec/lib/sqlite_crypto/type/uuid_spec.rb
@@ -39,6 +39,21 @@ RSpec.describe SqliteCrypto::Type::Uuid do
         expect { type.cast(invalid) }.to raise_error(ArgumentError, /Invalid UUID/)
       end
     end
+
+    it "rejects multiline strings with embedded newlines (security)" do
+      malicious = "550e8400-e29b-41d4-a716-446655440000\n<script>alert('xss')</script>"
+      expect { type.cast(malicious) }.to raise_error(ArgumentError, /Invalid UUID/)
+    end
+
+    it "rejects UUIDs with leading content" do
+      malicious = "prefix-550e8400-e29b-41d4-a716-446655440000"
+      expect { type.cast(malicious) }.to raise_error(ArgumentError, /Invalid UUID/)
+    end
+
+    it "rejects UUIDs with trailing content" do
+      malicious = "550e8400-e29b-41d4-a716-446655440000-suffix"
+      expect { type.cast(malicious) }.to raise_error(ArgumentError, /Invalid UUID/)
+    end
   end
 
   describe "#serialize and #deserialize" do

--- a/spec/lib/sqlite_crypto_spec.rb
+++ b/spec/lib/sqlite_crypto_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SqliteCrypto do
   describe "version" do
     it "has a version number" do
       expect(SqliteCrypto::VERSION).not_to be_nil
-      expect(SqliteCrypto::VERSION).to eq("2.0.0")
+      expect(SqliteCrypto::VERSION).to eq("2.0.1")
     end
   end
 
@@ -68,12 +68,6 @@ RSpec.describe SqliteCrypto do
   describe "initialization" do
     it "loads successfully" do
       expect(defined?(SqliteCrypto)).to eq("constant")
-    end
-  end
-
-  describe ".load_extensions" do
-    it "responds to load_extensions" do
-      expect(SqliteCrypto).to respond_to(:load_extensions)
     end
   end
 end

--- a/sqlite_crypto.gemspec
+++ b/sqlite_crypto.gemspec
@@ -9,8 +9,9 @@ Gem::Specification.new do |spec|
   spec.email = ["bartek.ozdoba@gmail.com"]
   spec.homepage = "https://github.com/bart-oz/sqlite_crypto"
   spec.license = "MIT"
-  spec.summary = "Seamless UUID/ULID support for Rails 8 with SQLite"
-  spec.description = "A lightweight, modular gem providing transparent UUID/ULID primary key configuration for Rails applications using SQLite."
+  spec.summary = "UUID (v4/v7) and ULID primary keys for Rails + SQLite3"
+  spec.description = "UUID and ULID primary key support for Rails with SQLite3. Provides automatic type registration, validation, foreign key detection, and clean schema generation. Supports UUIDv4 (random), UUIDv7 (time-ordered), and ULID (compact, time-sortable) with zero external dependencies."
+
   spec.files = Dir["lib/**/*", "README.md", "LICENSE.txt", "CHANGELOG.md", "bin/*"]
   spec.require_paths = ["lib"]
   spec.bindir = "bin"


### PR DESCRIPTION
- Fixed regex anchor vulnerability in UUID/ULID validators
- Fixed action_text-trix XSS vulnerability by updating the version to '>= 2.1.16'
- Eager configuration validation: Setting `uuid_version = :v7` on Ruby < 3.3 now fails at boot time with clear error message instead of runtime failure
- Namespace cleanup: `uuid` and `ulid` schema helpers now scoped to `ActiveRecord::Schema` instead of global `Object`
- Performance: Cached Ruby version check in `V7_AVAILABLE` constant (eliminates repeated `Gem::Version` comparisons)
- Boot time: Added lazy loading with `ActiveSupport.on_load(:active_record)` hook for faster Rails initialization
- Migration performance: Memoized primary key type detection to avoid redundant database queries
- Removed Unused `SqliteCrypto::Error` class
- Removed Unused `SqliteCrypto.load_extensions` placeholder method
- Simplified configuration defaults to reuse `Generators::Uuid.v7_available?` logic
- Improved code organization and removed dead code