### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-03-22
+
+### Added
+- **Auto primary key generation**: Models with UUID or ULID primary keys now automatically generate
+  their primary key on create — no explicit `generates_uuid`/`generates_ulid` call needed
+- `_sqlite_crypto_pk_type` class method for inspecting the detected primary key type (`:uuid`, `:ulid`, or `nil`).
+  Detection is based on column schema (string, limit 36 → `:uuid`; limit 26 → `:ulid`) and is cached per class
+
+### Acknowledgements
+- Thanks to [@joel](https://github.com/joel) for the contribution in [#20](https://github.com/bart-oz/sqlite_crypto/pull/20)
+
 ## [2.0.2] - 2026-02-11
 
 ### Fixed

--- a/lib/sqlite_crypto/version.rb
+++ b/lib/sqlite_crypto/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SqliteCrypto
-  VERSION = "2.0.2"
+  VERSION = "2.1.0"
   RUBY_MINIMUM_VERSION = "3.1.0"
   RAILS_MINIMUM_VERSION = "7.1.0"
 end

--- a/spec/lib/sqlite_crypto_spec.rb
+++ b/spec/lib/sqlite_crypto_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SqliteCrypto do
   describe "version" do
     it "has a version number" do
       expect(SqliteCrypto::VERSION).not_to be_nil
-      expect(SqliteCrypto::VERSION).to eq("2.0.2")
+      expect(SqliteCrypto::VERSION).to eq("2.1.0")
     end
   end
 


### PR DESCRIPTION
**Summary**
  - Bump version to 2.1.0
  - Update CHANGELOG with auto primary key generation
  feature (PR #20 by @joel)

**Changes**
  - `lib/sqlite_crypto/version.rb`: 2.0.2 → 2.1.0
  - `CHANGELOG.md`: added v2.1.0 section