### PR TITLE
feat: quality fixes for type casting, migration helpers, and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.3.0] - 2026-07-15
+
+### Security
+- Refreshed lockfiles, picking up fixes for transitive CVEs in `sqlite3`, `nokogiri`, `json`, `crass`, and `concurrent-ruby`
 
 ### Changed
 - Updated `.ruby-version` from `4.0.3` to `4.0.6`
-- CI: switched to `bundler-cache: true` with per-Rails `BUNDLE_GEMFILE`, replacing manual `bundle install` + `appraisal` invocations for faster runs
-- CI: security audit now uses the bundled `bundler-audit` (`bundle exec bundler-audit check --update`) instead of a separate gem install
-- CI: removed the empty "Enforce coverage threshold" step (SimpleCov enforces the 80% minimum in-process)
+- CI: cache bundler installs per Rails version, run `bundler-audit` from the bundle, and drop the empty coverage-threshold step
+- Narrowed the runtime dependency from `rails` to `activerecord` + `railties`, dropping the `action_text-trix` pin it required
+- **Tightened ULID validation**: rejects `I`, `L`, `O`, `U`, which Crockford base32 excludes
+
+### Fixed
+- **Reads no longer raise on malformed legacy IDs**: `Type::Base#deserialize` returns stored values as-is instead of re-validating them, so a corrupted row no longer crashes every read of it. Writes (`#cast`/`#serialize`) still validate strictly
+- **Primary-key type cache invalidation**: `_sqlite_crypto_pk_type` now clears on `reset_column_information` instead of going stale after a migration
+- **Adapter guard for auto ID generation**: primary-key detection now only applies to SQLite3 connections, not any string(36/26) primary key regardless of adapter
+- **`references`/`belongs_to` with `to_table` and `foreign_key: true`**: the foreign key now targets the correct table instead of the pluralized association name
 
 ## [2.2.0] - 2026-05-08
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,6 @@ source "https://rubygems.org"
 
 gemspec
 
-# Security: Fix Trix XSS vulnerability (GHSA-g9jg-w8vm-g96v)
-gem "action_text-trix", ">= 2.1.16"
-
 group :development do
   gem "rake", "~> 13.3.1"
   gem "standard", "~> 1.52.0"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://github.com/bart-oz/sqlite_crypto/releases">
-    <img src="https://img.shields.io/badge/version-2.2.0-blue.svg" alt="Version">
+    <img src="https://img.shields.io/badge/version-2.3.0-blue.svg" alt="Version">
   </a>
   <a href="LICENSE.txt">
     <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License">
@@ -41,7 +41,7 @@ end
 - Automatic foreign key type detection
 - Model-level ID generation
 - Clean schema.rb output
-- Lightweight runtime dependencies (`rails`, `sqlite3`, `ulid`)
+- Lightweight runtime dependencies (`activerecord`, `railties`, `sqlite3`, `ulid` — no full `rails` metagem)
 
 ## Compatibility
 

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "action_text-trix", ">= 2.1.16"
 gem "rails", "~> 7.1.0"
 
 group :development do

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "action_text-trix", ">= 2.1.16"
 gem "rails", "~> 7.2.0"
 
 group :development do

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "action_text-trix", ">= 2.1.16"
 gem "rails", "~> 8.0.0"
 
 group :development do

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "action_text-trix", ">= 2.1.16"
 gem "rails", "~> 8.1.0"
 
 group :development do

--- a/lib/sqlite_crypto/migration_helpers.rb
+++ b/lib/sqlite_crypto/migration_helpers.rb
@@ -18,11 +18,17 @@ module SqliteCrypto
     module References
       def references(*args, **options)
         ref_name = args.first
-        ref_table = options.delete(:to_table) || ref_name.to_s.pluralize
+        explicit_to_table = options.delete(:to_table)
+        ref_table = explicit_to_table || ref_name.to_s.pluralize
 
         if (primary_key_type = detect_primary_key_type(ref_table))
           options[:type] ||= :string
           options[:limit] ||= IdTypes.string_limit_for(primary_key_type)
+        end
+
+        if explicit_to_table && options[:foreign_key]
+          fk_options = options[:foreign_key].is_a?(Hash) ? options[:foreign_key] : {}
+          options[:foreign_key] = fk_options.reverse_merge(to_table: explicit_to_table)
         end
 
         super

--- a/lib/sqlite_crypto/model_extensions.rb
+++ b/lib/sqlite_crypto/model_extensions.rb
@@ -50,11 +50,17 @@ module SqliteCrypto
         @_sqlite_crypto_pk_type = _detect_sqlite_crypto_pk_type
       end
 
+      def reset_column_information
+        remove_instance_variable(:@_sqlite_crypto_pk_type) if defined?(@_sqlite_crypto_pk_type)
+        super
+      end
+
       private
 
       def _detect_sqlite_crypto_pk_type
         return nil if abstract_class?
         return nil unless table_exists?
+        return nil unless connection.adapter_name == "SQLite"
 
         pk = primary_key
         return nil unless pk

--- a/lib/sqlite_crypto/type/base.rb
+++ b/lib/sqlite_crypto/type/base.rb
@@ -4,8 +4,7 @@ module SqliteCrypto
   module Type
     class Base < ActiveRecord::Type::String
       def deserialize(value)
-        return if value.nil?
-        cast(value)
+        value&.to_s
       end
 
       def cast(value)
@@ -25,7 +24,7 @@ module SqliteCrypto
       end
 
       def changed_in_place?(raw_old_value, new_value)
-        cast(raw_old_value) != cast(new_value)
+        deserialize(raw_old_value) != cast(new_value)
       end
 
       private

--- a/lib/sqlite_crypto/type/ulid.rb
+++ b/lib/sqlite_crypto/type/ulid.rb
@@ -5,7 +5,8 @@ require "sqlite_crypto/type/base"
 module SqliteCrypto
   module Type
     class ULID < Base
-      ULID_PATTERN = /\A[0-7][0-9A-Z]{25}\z/i
+      # Crockford base32 excludes I, L, O, U to avoid confusion with 1, 0.
+      ULID_PATTERN = /\A[0-7][0-9A-HJKMNP-TV-Z]{25}\z/i
 
       def type
         :ulid

--- a/lib/sqlite_crypto/version.rb
+++ b/lib/sqlite_crypto/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SqliteCrypto
-  VERSION = "2.2.0"
+  VERSION = "2.3.0"
   RUBY_MINIMUM_VERSION = "3.1.0"
   RAILS_MINIMUM_VERSION = "7.1.0"
 end

--- a/spec/lib/sqlite_crypto/migration_helpers_spec.rb
+++ b/spec/lib/sqlite_crypto/migration_helpers_spec.rb
@@ -60,6 +60,17 @@ RSpec.describe "Migration Helpers" do
         expect(author_id_col.sql_type).to eq("varchar(36)")
       end
 
+      it "targets the actual foreign key constraint at to_table, not the pluralized association name" do
+        connection.create_table :posts do |t|
+          t.belongs_to :author, to_table: :users, foreign_key: true
+        end
+
+        foreign_key = connection.foreign_keys(:posts).find { |fk| fk.column == "author_id" }
+
+        expect(foreign_key).not_to be_nil
+        expect(foreign_key.to_table).to eq("users")
+      end
+
       it "allows explicit type override" do
         connection.create_table :posts do |t|
           t.references :user, type: :integer

--- a/spec/lib/sqlite_crypto/model_extensions_spec.rb
+++ b/spec/lib/sqlite_crypto/model_extensions_spec.rb
@@ -277,5 +277,44 @@ RSpec.describe SqliteCrypto::ModelExtensions do
 
       connection.drop_table :pk_cache_test, if_exists: true
     end
+
+    it "recomputes after reset_column_information invalidates the cache" do
+      connection.create_table :pk_reset_test, force: true do |t|
+        t.string :name
+      end
+
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = "pk_reset_test"
+      end
+
+      expect(klass._sqlite_crypto_pk_type).to be_nil
+
+      connection.create_table :pk_reset_test, id: :uuid, force: true do |t|
+        t.string :name
+      end
+      klass.reset_column_information
+
+      expect(klass._sqlite_crypto_pk_type).to eq(:uuid)
+
+      connection.drop_table :pk_reset_test, if_exists: true
+    end
+
+    it "returns nil for non-SQLite connections even with a UUID-shaped primary key" do
+      connection.create_table :pk_other_adapter_test, id: :uuid, force: true do |t|
+        t.string :name
+      end
+
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = "pk_other_adapter_test"
+      end
+
+      other_connection = instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter, adapter_name: "PostgreSQL")
+      allow(klass).to receive(:connection).and_return(other_connection)
+      allow(klass).to receive(:table_exists?).and_return(true)
+
+      expect(klass._sqlite_crypto_pk_type).to be_nil
+
+      connection.drop_table :pk_other_adapter_test, if_exists: true
+    end
   end
 end

--- a/spec/lib/sqlite_crypto/type/ulid_spec.rb
+++ b/spec/lib/sqlite_crypto/type/ulid_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe SqliteCrypto::Type::ULID do
       end
     end
 
+    it "rejects Crockford base32 excluded letters I, L, O, U" do
+      %w[I L O U].each do |excluded_letter|
+        invalid = valid_ulid.dup
+        invalid[1] = excluded_letter
+        expect { type.cast(invalid) }.to raise_error(ArgumentError, /Invalid ULID/)
+      end
+    end
+
     it "rejects multiline strings with embedded newlines (security)" do
       malicious = "01ARZ3NDEKTSV4RRFFQ69G5FAV\n<script>alert('xss')</script>"
       expect { type.cast(malicious) }.to raise_error(ArgumentError, /Invalid ULID/)
@@ -73,6 +81,15 @@ RSpec.describe SqliteCrypto::Type::ULID do
       expect(type.serialize(nil)).to be_nil
       expect(type.deserialize(nil)).to be_nil
     end
+
+    it "does not raise for malformed values already stored in the database" do
+      legacy_value = "not-a-ulid"
+      expect(type.deserialize(legacy_value)).to eq(legacy_value)
+    end
+
+    it "still raises ArgumentError when writing an invalid value" do
+      expect { type.serialize("not-a-ulid") }.to raise_error(ArgumentError, /Invalid ULID/)
+    end
   end
 
   describe "#changed_in_place?" do
@@ -83,6 +100,11 @@ RSpec.describe SqliteCrypto::Type::ULID do
       expect(type.changed_in_place?(ulid1, ulid1)).to be false
       expect(type.changed_in_place?(ulid1, ulid2)).to be true
       expect(type.changed_in_place?(nil, ulid1)).to be true
+    end
+
+    it "does not raise when the persisted value is a malformed legacy id" do
+      expect(type.changed_in_place?("not-a-ulid", valid_ulid)).to be true
+      expect(type.changed_in_place?("not-a-ulid", nil)).to be true
     end
   end
 end

--- a/spec/lib/sqlite_crypto/type/uuid_spec.rb
+++ b/spec/lib/sqlite_crypto/type/uuid_spec.rb
@@ -66,6 +66,15 @@ RSpec.describe SqliteCrypto::Type::Uuid do
       expect(type.serialize(nil)).to be_nil
       expect(type.deserialize(nil)).to be_nil
     end
+
+    it "does not raise for malformed values already stored in the database" do
+      legacy_value = "not-a-uuid"
+      expect(type.deserialize(legacy_value)).to eq(legacy_value)
+    end
+
+    it "still raises ArgumentError when writing an invalid value" do
+      expect { type.serialize("not-a-uuid") }.to raise_error(ArgumentError, /Invalid UUID/)
+    end
   end
 
   describe "#changed_in_place?" do
@@ -76,6 +85,11 @@ RSpec.describe SqliteCrypto::Type::Uuid do
       expect(type.changed_in_place?(uuid1, uuid1)).to be false
       expect(type.changed_in_place?(uuid1, uuid2)).to be true
       expect(type.changed_in_place?(nil, uuid1)).to be true
+    end
+
+    it "does not raise when the persisted value is a malformed legacy id" do
+      expect(type.changed_in_place?("not-a-uuid", valid_uuid)).to be true
+      expect(type.changed_in_place?("not-a-uuid", nil)).to be true
     end
   end
 end

--- a/spec/lib/sqlite_crypto_spec.rb
+++ b/spec/lib/sqlite_crypto_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SqliteCrypto do
   describe "version" do
     it "has a version number" do
       expect(SqliteCrypto::VERSION).not_to be_nil
-      expect(SqliteCrypto::VERSION).to eq("2.2.0")
+      expect(SqliteCrypto::VERSION).to eq("2.3.0")
     end
   end
 

--- a/sqlite_crypto.gemspec
+++ b/sqlite_crypto.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/bart-oz/sqlite_crypto"
   spec.license = "MIT"
   spec.summary = "UUID (v4/v7) and ULID primary keys for Rails + SQLite3"
-  spec.description = "UUID and ULID primary key support for Rails with SQLite3. Provides automatic type registration, validation, foreign key detection, and clean schema generation. Supports UUIDv4 (random), UUIDv7 (time-ordered), and ULID (compact, time-sortable) with zero external dependencies."
+  spec.description = "UUID and ULID primary key support for Rails with SQLite3. Provides automatic type registration, validation, foreign key detection, and clean schema generation. Supports UUIDv4 (random), UUIDv7 (time-ordered), and ULID (compact, time-sortable)."
 
   spec.files = Dir["lib/**/*", "README.md", "LICENSE.txt", "CHANGELOG.md", "bin/*"]
   spec.require_paths = ["lib"]
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= #{SqliteCrypto::RUBY_MINIMUM_VERSION}"
 
-  spec.add_dependency "rails", ">= #{SqliteCrypto::RAILS_MINIMUM_VERSION}"
+  spec.add_dependency "activerecord", ">= #{SqliteCrypto::RAILS_MINIMUM_VERSION}"
+  spec.add_dependency "railties", ">= #{SqliteCrypto::RAILS_MINIMUM_VERSION}"
   spec.add_dependency "sqlite3", ">= 1.6.0"
   spec.add_dependency "ulid", "~> 1.0"
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
## Summary of changes:
- Reads no longer raise on malformed legacy IDs; writes still validate strictly
- Tighten ULID validation to the real Crockford alphabet
- Fix stale primary-key type cache and restrict auto ID generation to SQLite3
- Fix references/belongs_to with to_table + foreign_key: true targeting the wrong table
- Narrow runtime dependency from rails to activerecord + railties
- Refresh lockfiles, fixing several transitive CVEs

Release v2.3.0.